### PR TITLE
Pin nixpkgs to nixos-24.05 channel

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,12 +19,7 @@
     "vscode": {
       "settings": {
         "editor.defaultFormatter": "dprint.dprint",
-        "editor.formatOnSave": true,
-        "hadolint.hadolintPath": "/nix/store/3gl6j30ak4n692vfs5l1rsqf07pdr429-hadolint-2.12.0/bin/hadolint",
-        "dprint.path": "/nix/store/2rmr7ybmnr5xdcy6sw1073p0j5ljgw0n-dprint-0.37.1/bin/dprint",
-        "[nix]": {
-          "editor.defaultFormatter": "jnoortheen.nix-ide"
-        }
+        "editor.formatOnSave": true
       },
       "extensions": [
         "github.vscode-github-actions",

--- a/.github/workflows/bump-flake-lock-and-selfup.yml
+++ b/.github/workflows/bump-flake-lock-and-selfup.yml
@@ -12,12 +12,12 @@ on:
 
 jobs:
   bump:
-    uses: kachick/selfup/.github/workflows/reusable-bump-flake-lock-and-selfup.yml@action-v1
+    uses: kachick/selfup/.github/workflows/reusable-bump-flake-lock-and-selfup.yml@236e552774af3d967d888e24ce9834a5b424c2c7 #v1.1.3
     if: (github.event.sender.login == 'kachick') || (github.event_name != 'pull_request')
     with:
+      app_id: ${{ vars.APP_ID }}
       dry-run: ${{ github.event_name == 'pull_request' }}
       optional-run: |
         echo 'Add another changes and git commit here, especially for .node-version/.ruby-version'
     secrets:
-      APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,14 +13,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dprint/check@v2.2
         with:
-          dprint-version: '0.46.3' # selfup {"extract":"\\d[^']+","replacer":["bash","-c","dprint --version | cut -d ' ' -f 2"]}
+          dprint-version: '0.45.1' # selfup {"extract":"\\d[^']+","replacer":["bash","-c","dprint --version | cut -d ' ' -f 2"]}
 
   typos:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.22.9 # selfup {"extract":"\\d\\.\\d+\\.\\d+","replacer":["bash","-c","typos --version | cut -d ' ' -f 2"]}
+      - uses: crate-ci/typos@v1.21.0 # selfup {"extract":"\\d\\.\\d+\\.\\d+","replacer":["bash","-c","typos --version | cut -d ' ' -f 2"]}
         with:
           files: |
             .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,14 +13,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dprint/check@v2.2
         with:
-          dprint-version: '0.46.3' # selfup { "regex": "\\d[^']+", "script": "dprint --version | cut -d ' ' -f 2" }
+          dprint-version: '0.46.3' # selfup {"extract":"\\d[^']+","replacer":["bash","-c","dprint --version | cut -d ' ' -f 2"]}
 
   typos:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.22.9 # selfup { "regex": "\\d\\.\\d+\\.\\d+", "script": "typos --version | cut -d ' ' -f 2" }
+      - uses: crate-ci/typos@v1.22.9 # selfup {"extract":"\\d\\.\\d+\\.\\d+","replacer":["bash","-c","typos --version | cut -d ' ' -f 2"]}
         with:
           files: |
             .

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,14 @@
   "editor.formatOnSave": true,
   "[nix]": {
     "editor.defaultFormatter": "jnoortheen.nix-ide"
+  },
+  "nix.enableLanguageServer": true,
+  "nix.serverPath": "nil",
+  "nix.serverSettings": {
+    "nil": {
+      "formatting": {
+        "command": ["nixfmt"]
+      }
+    }
   }
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,13 +18,14 @@ tasks:
     cmds:
       - typos . .github .vscode .devcontainer --write-changes
       - dprint fmt
-      - nixpkgs-fmt ./*.nix
+      - git ls-files '*.nix' | xargs nix fmt
   lint:
     # go fmt does not have option for no effect - https://github.com/golang/go/issues/41189
     cmds:
       - dprint check
       - typos . .github .vscode .devcontainer
-      - nixpkgs-fmt --check ./*.nix
+      # nix fmt doesn't have check: https://github.com/NixOS/nix/issues/6918
+      - git ls-files '*.nix' | xargs nixfmt --check
       - 'hadolint .devcontainer/Dockerfile'
   deps:
     cmds:

--- a/dprint.json
+++ b/dprint.json
@@ -7,8 +7,8 @@
   },
   "includes": ["**/*.{json,md,yml}"],
   "plugins": [
-    "https://plugins.dprint.dev/json-0.19.2.wasm",
-    "https://plugins.dprint.dev/markdown-0.16.4.wasm",
-    "https://plugins.dprint.dev/prettier-0.39.0.json@896b70f29ef8213c1b0ba81a93cee9c2d4f39ac2194040313cd433906db7bc7c"
+    "https://plugins.dprint.dev/json-0.19.3.wasm",
+    "https://plugins.dprint.dev/markdown-0.17.1.wasm",
+    "https://plugins.dprint.dev/prettier-0.40.0.json@68c668863ec834d4be0f6f5ccaab415df75336a992aceb7eeeb14fdf096a9e9c"
   ]
 }

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719506693,
-        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
+        "lastModified": 1719956923,
+        "narHash": "sha256-nNJHJ9kfPdzYsCOlHOnbiiyKjZUW5sWbwx3cakg3/C4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
+        "rev": "706eef542dec88cc0ed25b9075d3037564b2d164",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     #   - https://discourse.nixos.org/t/differences-between-nix-channels/13998
     # How to update the revision
     #   - `nix flake update --commit-lock-file` # https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake-update.html
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,13 +9,21 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
       in
       {
-        devShells.default = with pkgs;
+        formatter = pkgs.nixfmt-rfc-style;
+        devShells.default =
+          with pkgs;
           mkShell {
             buildInputs = [
               # https://github.com/NixOS/nix/issues/730#issuecomment-162323824
@@ -23,7 +31,7 @@
               bashInteractive
 
               nil
-              nixpkgs-fmt
+              nixfmt-rfc-style
               go-task
               dprint
               typos
@@ -32,5 +40,6 @@
               coreutils
             ];
           };
-      });
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
               dprint
               typos
 
+              # TODO: Replace with trivy
               hadolint
               coreutils
             ];


### PR DESCRIPTION
- **Bump and pin to NixOS 24.05**
- **`git ls-files '.github/workflows/*.yml' | xargs nix run github:kachick/selfup/v1.1.3 -- migrate`**
- **`git ls-files '.github/workflows/*.yml' | xargs nix run github:kachick/selfup/v1.1.3 -- run`**
- **Follow selfup v1.1.3 in action**
- **Replace nixpkgs-fmt with nixfmt-rfc-style**
- **Remove unsynched settings in devcontainaer**
- **Add note about deprecated hadolint**
